### PR TITLE
Fix runtime

### DIFF
--- a/src/Oxide.Runtime/Oxide.Runtime.csproj
+++ b/src/Oxide.Runtime/Oxide.Runtime.csproj
@@ -22,10 +22,16 @@
     <IncludeBuildOutput>false</IncludeBuildOutput>
   </PropertyGroup>
 
-  <ItemGroup>
-    <None Include="runtimes\**\*">
+  <ItemGroup Label="Native libraries">
+    <!-- See https://github.com/ppy/osu-framework/blob/master/osu.Framework.NativeLibs/osu.Framework.NativeLibs.csproj. -->
+    <None Include="runtimes\**\*" Pack="true" PackagePath="runtimes" />
+    <None Include="_._">
+      <!-- Means this package doesn't provide any reference assembly to the target framework.
+           nupkg is a zip file and doesn't has concept for folders,
+           so there must be something under the path, otherwise client will consider this package broken.
+           See https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128#scenario-2 . -->
       <Pack>true</Pack>
-      <PackagePath>runtimes</PackagePath>
+      <PackagePath>lib\$(TargetFramework)</PackagePath>
     </None>
   </ItemGroup>
 

--- a/src/Oxide.Runtime/Oxide.Runtime.csproj
+++ b/src/Oxide.Runtime/Oxide.Runtime.csproj
@@ -26,10 +26,6 @@
     <!-- See https://github.com/ppy/osu-framework/blob/master/osu.Framework.NativeLibs/osu.Framework.NativeLibs.csproj. -->
     <None Include="runtimes\**\*" Pack="true" PackagePath="runtimes" />
     <None Include="_._">
-      <!-- Means this package doesn't provide any reference assembly to the target framework.
-           nupkg is a zip file and doesn't has concept for folders,
-           so there must be something under the path, otherwise client will consider this package broken.
-           See https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128#scenario-2 . -->
       <Pack>true</Pack>
       <PackagePath>lib\$(TargetFramework)</PackagePath>
     </None>

--- a/src/Oxide.Runtime/Oxide.Runtime.csproj
+++ b/src/Oxide.Runtime/Oxide.Runtime.csproj
@@ -16,7 +16,7 @@
     <PackageTags>Framework;UI;HTML5;Ultralight</PackageTags>
     <Title>Oxide.Runtime</Title>
     <Description>Native runtime libraries for Oxide</Description>
-    <Copyright>2022 ©️Vignette</Copyright>
+    <Copyright>2022 The Vignette Authors;Ultralight</Copyright>
     <PackageProjectUrl>https://github.com/vignetteapp/Oxide</PackageProjectUrl>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
     <IncludeBuildOutput>false</IncludeBuildOutput>


### PR DESCRIPTION
This fixes the `Oxide.Runtime` project so that we can package it and then publish it to Nuget for further development, as it is guaranteed to work unlike references.